### PR TITLE
[fix] docer compose yamlの修正

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,8 +2,9 @@ services:
   web:
     container_name: web
     build:
+      context: .
       dockerfile: ./Dockerfile
     working_dir: /workspace/web
     volumes:
-      - ..:/workspace/web:cache
+      - ..:/workspace/web:cached
     tty: true


### PR DESCRIPTION
build contextの追加
context: .

volumeのcachedの変更
docker の公式ドキュメント探したけど、欠落しています．
https://github.com/docker/docs/issues/13519
https://github.com/docker/docs/issues/11884
正式な使用方法は
:cached or :delegatedかもです．

以下エラー:
`[2024-05-12T05:43:16.532Z] The Compose file is invalid because:`
`Service web has neither an image nor a build context specified. At least one must be provided.`

`ERROR: for web  Cannot create container for service web: invalid mode: cache`
