### PR TITLE
redisを追加し、channelsの基盤を用意する。

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,13 +32,20 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+          condition: service_healthy
     env_file:
       - .env
 
+  redis:
+    image: "redis:7.4-rc2"
+    ports:
+      - "6379:6379"
+    healthcheck:
+        test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+
   db:
-    build:
-      context: ./requirements/Postgres/
-      dockerfile: ./Containerfile
+    image: "postgres:15.2"
     ports:
       - "5432:5432"
     volumes:

--- a/.devcontainer/requirements/Django/entrypoint.sh
+++ b/.devcontainer/requirements/Django/entrypoint.sh
@@ -11,5 +11,5 @@ python manage.py collectstatic --no-input
 if [ $DEBUG = 1 ]; then
     exec python manage.py runserver 0.0.0.0:8000
 else
-    exec gunicorn config.wsgi:application --bind 0.0.0.0:8000
+    exec uvicorn config.asgi:application --host 0.0.0.0 --port 8000
 fi

--- a/.devcontainer/requirements/Django/requirements.txt
+++ b/.devcontainer/requirements/Django/requirements.txt
@@ -8,3 +8,7 @@ psycopg2==2.9.9
 pycparser==2.22
 PyJWT==2.8.0
 sqlparse==0.5.0
+uvicorn==0.30.1
+channels==4.1.0
+channels_redis==4.2.0
+websocket==0.2.1

--- a/.devcontainer/requirements/Nginx/conf.d/default.conf
+++ b/.devcontainer/requirements/Nginx/conf.d/default.conf
@@ -2,14 +2,24 @@ upstream django {
 	server app:8000;
 }
 
+map $http_upgrade $connection_upgrade {
+		default	upgrade;
+		''			close;
+}
+
 server {
 	listen 80;
 	server_name 0.0.0.0;
+
+	proxy_http_version 1.1;
+	proxy_set_header Host $host;
+	proxy_set_header X-forwarded-For $proxy_add_x_forwarded_for;
+	proxy_set_header Upgrade $http_upgrade;
+	proxy_set_header Connection $connection_upgrade;
+	proxy_redirect off;
+
 	location / {
-		proxy_pass http://django;
-		proxy_set_header Host $host;
-		proxy_set_header X-forwarded-For $proxy_add_x_forwarded_for;
-		proxy_redirect off;
+				proxy_pass http://django;
 	}
 }
 

--- a/pong/config/asgi.py
+++ b/pong/config/asgi.py
@@ -9,8 +9,25 @@ https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
 
 import os
 
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
+from django.urls import path
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+django_asgi_app = application = get_asgi_application()
 
-application = get_asgi_application()
+# import consumers here
+
+application = ProtocolTypeRouter({
+    "http": django_asgi_app,
+    "websocket": AllowedHostsOriginValidator(
+        AuthMiddlewareStack(
+            URLRouter([
+                #path("chat/admin/", AdminChatConsumer.as_asgi()),
+                #path("chat/", PublicChatConsumer.as_asgi()), 
+            ])
+        )
+    ),
+})

--- a/pong/config/settings.py
+++ b/pong/config/settings.py
@@ -147,3 +147,13 @@ JWT_AUTH = {
     'JWT_PUBLIC_KEY': PUBLIC_KEY,
     'JWT_ALGORITHM': 'RS256',
 }
+
+# channelsのためのlayerの追加　
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [("redis", 6379)],
+        },
+    },
+}


### PR DESCRIPTION
redisをプロジェクトに追加して、channelsの基盤を用意しました。
これに当たって以下の点を変更を加えました。
- docker-composeにredisを追加
- wsgiからasgiへ変更(非同期処理を行うため)
- asgi.pyにプロトコルによって処理を分岐させる
- djangoにchannelsのlayerを保存するredisのアドレスとポートを指定する
- httpからwebsocketにプロトコルを[Update](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Upgrade)したことをアプリケーションサーバに知らせるために、nginxのconfigの一部を書き換える。

変更の理由と注意
- in-memoryのchannel-layerで利用できないworkerやバックグラウンドで行うタスクの設定などがredisを使用すると利用できます。
- redisを追加したことにより、マイナーモジュールのdbに記されている "The designated database for all DB instances in your project is PostgreSQL"の制約を満たさなくなります。
   これに関しては私が同じくマイナーモジュールである”Monitoring system”をやることで解決しようと思います。

