### PR TITLE
Using getJwtPayload or getJwtPayloadCookie to verify JWT token instead of getUserByJwtCookie

### DIFF
--- a/pong/pong/middleware/auth.py
+++ b/pong/pong/middleware/auth.py
@@ -16,21 +16,32 @@ def jwt_exempt(view_func):
 	_wrapped_view_func.jwt_exempt = True
 	return _wrapped_view_func
 
-def getUserByJwt(token):
+def getJwtPayload(token):
 	if not token:
 		return None
 	try:
 		payload = jwt.decode(token, settings.JWT_AUTH['JWT_PUBLIC_KEY'], algorithms=[settings.JWT_AUTH['JWT_ALGORITHM']])
 	except jwt.ExpiredSignatureError or jwt.InvalidTokenError:
 		return None
+	return payload
+
+def getUserByJwt(token):
+	payload = getJwtPayload(token)
+	if not payload:
+		return None
 	user = User.objects.filter(uuid=payload['uuid']).first()
 	if not user:
 		return None
 	return user
-	
-def getUserByJwtCookie(request):
-	token = request.COOKIES.get('token')
-	return getUserByJwt(token)
+
+def getJwtPayloadCookie(request):
+	token = request.COOKIES.get('token', None)
+	if not token:
+		return None
+	payload = getJwtPayload(token)
+	if not payload:
+		return None
+	return payload
 
 class JWTAuthenticationMiddleware:
 
@@ -44,8 +55,7 @@ class JWTAuthenticationMiddleware:
 		if getattr(view_func, 'jwt_exempt', False):
 			return None
 
-		user = getUserByJwtCookie(request)
-		if not user:
+		if not getJwtPayloadCookie(request):
 			return JsonResponse({
 				'message': 'unauthorized',
 				'status': 'unauthorized'

--- a/pong/pong/views/auth.py
+++ b/pong/pong/views/auth.py
@@ -6,7 +6,7 @@ from django.views.decorators.csrf import csrf_exempt
 from datetime import datetime, timedelta
 from django.conf import settings
 from django.http.response import HttpResponse
-from pong.middleware.auth import jwt_exempt, getUserByJwtCookie
+from pong.middleware.auth import jwt_exempt, getJwtPayloadCookie
 from pong.utils.create_response import create_token_response
 import requests
 import jwt
@@ -124,13 +124,14 @@ def verify_token(request):
 			'status': 'invalidParams'
 		}, status=400)
 
-	user = getUserByJwtCookie(request)
-	if not user:
+	payload = getJwtPayloadCookie(request)
+	uuid = payload.get('uuid', None)
+	if not payload or not uuid:
 		return JsonResponse({
 			'message': 'unauthorized',
 			'status': 'unauthorized'
 		}, status=401)
 
 	return JsonResponse({
-		'uuid': str(user.uuid)
+		'uuid': str(uuid)
 	}, status=200)


### PR DESCRIPTION
Close #76 .