### PR TITLE
refs #121 enable component to execute lifecycle hooks

### DIFF
--- a/pong/pong/static/pong/core/component.js
+++ b/pong/pong/static/pong/core/component.js
@@ -20,7 +20,9 @@ export class Component {
   }
   set html(newHtml) {}
 
-  onEnterForeground() {}
+  afterPageLoaded() {}
+
+  beforePageUnload() {}
 
   goNextPage = (path) => {
     this.router.goNextPage(path);

--- a/pong/pong/static/pong/core/router.js
+++ b/pong/pong/static/pong/core/router.js
@@ -45,6 +45,7 @@ export class Router {
     let component = new route.component(this, route.parameters, route.state);
 
     if (0 < this.pageStack.length) {
+      this.getForegroundPage.beforePageUnload();
       this.getForegroundPage.element.parentNode.removeChild(
         this.getForegroundPage.element,
       );
@@ -62,7 +63,7 @@ export class Router {
     }
     this.pageStack.push(component);
     this.rootElement.appendChild(component.element);
-    component.onEnterForeground();
+    component.afterPageLoaded();
     return component;
   }
 
@@ -73,15 +74,17 @@ export class Router {
     }
 
     let currentPage = this.pageStack.pop();
+    currentPage.beforePageUnload();
     currentPage.router = null;
     currentPage.element.parentNode.removeChild(currentPage.element);
 
     let page = this.getForegroundPage;
     this.rootElement.appendChild(page.element);
-    page.onEnterForeground();
+    page.afterPageLoaded();
   }
 
   onHistoryForward(data) {
+    this.getForegroundPage.beforePageUnload();
     this.getForegroundPage.element.parentNode.removeChild(
       this.getForegroundPage.element,
     );
@@ -95,7 +98,7 @@ export class Router {
     this.pageStack.push(component);
 
     this.rootElement.appendChild(component.element);
-    component.onEnterForeground();
+    component.afterPageLoaded();
   }
 
   searchRouteFromPath(path) {


### PR DESCRIPTION
#121 

## 内容

componentのロード時とアンロード時に特定の動作ができるようにhookを用意しました。
例えば、Homeコンポーネントがロードされた際に、Headerコンポーネントを追加し、ページがアンロードされたときにHeaderコンポーネントを削除したい場合、Homeコンポーネント内で以下のような記述をすることで可能になります。

```javascript
export class Home extends Component {
   ...

  afterPageLoaded() {
    this.headerComponent = new Header(this.router, this.params, this.state);
    this.element.parentElement.prepend(this.headerComponent.element);
  }

  beforePageUnload() {
    this.element.parentElement.removeChild(this.headerComponent.element);
  }
  ...
}
```
## なぜ必要か？

afterPageLoaded関数の処理はcomponentのコンストラクタでも良い気がしますが、afterPageLoaded関数の方がより柔軟な操作ができます。
例えば、componentのコンストラクタではparenetElement属性によって親elemenentの取得ができません。
これはcomponentのインスタンス作成時にはまだ、DOMにcomponentのelementが追加されていないためです。
afterPageLoaded関数が実行されるのはcomponentのelementがDOMについかされたあとであるため、parenetElement属性によって親elemenentの取得が可能になります。