### PR TITLE
Ignored files and directories other than pong/static/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,7 +161,9 @@ cython_debug/
 
 
 ## avoid static
-pong/static/
+!pong/static/
+pong/static/*
+!pong/static/.gitkeep
 #ignore extra files
 node_modules/
 


### PR DESCRIPTION
- `pong/static`配下のディレクトリやファイルは管理しないが、`pong/static`のディレクトリの存在のみ管理するように変更