### PR TITLE
ユーザーアイコンをヘッダーに反映させる

### DIFF
--- a/pong/pong/static/pong/components/Header.js
+++ b/pong/pong/static/pong/components/Header.js
@@ -1,9 +1,10 @@
 import { Component } from "../core/component.js";
-import { getUsersDataFromName } from "../api/api.js";
+import { getUuid, getUserFromUuid, getUsersDataFromName } from "../api/api.js";
 
 export class Header extends Component {
   constructor(router, params, state) {
     super(router, params, state);
+    this.loadHeader();
   }
 
   afterPageLoaded() {
@@ -26,6 +27,23 @@ export class Header extends Component {
       this.onClickSettingsButton;
     document.getElementById("navigate-signout-link").onclick =
       this.onClickSignoutButton;
+  }
+
+  async loadHeader() {
+    try {
+      const uuid = await getUuid();
+      if (!uuid) {
+        throw new Error("UUID not found");
+      }
+      const user = await getUserFromUuid(uuid);
+      if (!user) {
+        throw new Error("User not found");
+      }
+      this.findElements("#user-icon").src = user.icon
+    }
+    catch (error) {
+      console.error("Failed to load user profile:", error);
+    }
   }
 
   onSubmitSearchUserForm = async (event) => {
@@ -112,7 +130,7 @@ export class Header extends Component {
           </form>
           <button id="user-profile-button" class="btn btn-link"">
             <span class="Button-content">
-              <span class="Button-label"><img src="https://avatars.githubusercontent.com/u/110250805?v=4" alt="" size="32" height="32" width="32" data-view-component="true" class="avatar rounded-circle"></span>
+              <span class="Button-label"><img id="user-icon" size="32" height="32" width="32" data-view-component="true" class="avatar rounded-circle"></span>
             </span>
           </button>
         </div>
@@ -160,7 +178,7 @@ export class Header extends Component {
               <button id="navigate-stats-link" class="btn btn-link nav-link active" aria-current="page">
                 <i class="bi bi-graph-up px-2 fa-2x"></i>
                 <span class="fa-2x align-bottom">
-                  Stats 
+                  Stats
                 </span>
               </button>
             </li>
@@ -186,3 +204,4 @@ export class Header extends Component {
     `;
   }
 }
+

--- a/pong/pong/static/pong/components/Header.js
+++ b/pong/pong/static/pong/components/Header.js
@@ -41,13 +41,12 @@ export class Header extends Component {
       }
       this.findElement("#user-icon").src = user.icon;
       console.log(user.icon);
-    }
-    catch (error) {
+    } catch (error) {
       console.error("Failed to load user profile:", error);
     }
   }
 
-  onSubmitSearchUserForm = async (event) =>  {
+  onSubmitSearchUserForm = async (event) => {
     event.preventDefault();
     const searchedName = event.target.elements["search-user-input"].value;
     this.setRouteContext(
@@ -205,4 +204,3 @@ export class Header extends Component {
     `;
   }
 }
-

--- a/pong/pong/static/pong/components/Header.js
+++ b/pong/pong/static/pong/components/Header.js
@@ -130,7 +130,7 @@ export class Header extends Component {
           </form>
           <button id="user-profile-button" class="btn btn-link"">
             <span class="Button-content">
-              <span class="Button-label"><img id="user-icon" size="32" height="32" width="32" data-view-component="true" class="avatar rounded-circle"></span>
+              <span class="Button-label"><img id="user-icon" height="32" width="32" data-view-component="true" class="avatar rounded-circle"></span>
             </span>
           </button>
         </div>

--- a/pong/pong/static/pong/components/Header.js
+++ b/pong/pong/static/pong/components/Header.js
@@ -4,10 +4,10 @@ import { getUuid, getUserFromUuid, getUsersDataFromName } from "../api/api.js";
 export class Header extends Component {
   constructor(router, params, state) {
     super(router, params, state);
-    this.loadHeader();
   }
 
   afterPageLoaded() {
+    this.loadHeader();
     document.getElementById("search-user-form").onsubmit =
       this.onSubmitSearchUserForm;
     document.getElementById("title-link").onclick = this.onClickHomeLink;
@@ -39,14 +39,15 @@ export class Header extends Component {
       if (!user) {
         throw new Error("User not found");
       }
-      this.findElements("#user-icon").src = user.icon
+      this.findElement("#user-icon").src = user.icon;
+      console.log(user.icon);
     }
     catch (error) {
       console.error("Failed to load user profile:", error);
     }
   }
 
-  onSubmitSearchUserForm = async (event) => {
+  onSubmitSearchUserForm = async (event) =>  {
     event.preventDefault();
     const searchedName = event.target.elements["search-user-input"].value;
     this.setRouteContext(

--- a/pong/pong/static/pong/components/Profile.js
+++ b/pong/pong/static/pong/components/Profile.js
@@ -52,7 +52,9 @@ export class Profile extends Component {
     return `
         <div class="profile-card">
             <h1>プロフィールページ</h1>
-            <img id="user-icon">
+            <img id="user-icon" height="256" width="256">
+            <br>
+            <br>
             <p><strong>Username:</strong> <span id="username"></span></p>
             <p><strong>E-mail:</strong> <span id="email"></span></p>
             <br>


### PR DESCRIPTION
- ユーザーアイコンをヘッダー右上のプロフィール画面に遷移するボタンに反映させました。
- プロフィール画面の画像サイズを256x256に固定しました。
<img width="1099" alt="スクリーンショット 2024-10-05 19 30 28" src="https://github.com/user-attachments/assets/e43d214f-6324-458f-ad1d-21f9b240a708">
