### PR TITLE
feat: refs #178 PongGameの画面遷移を制御する

### DIFF
--- a/pong/config/settings.py
+++ b/pong/config/settings.py
@@ -169,6 +169,8 @@ CHANNEL_LAYERS = {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [("redis", REDIS_PORT)],
+            "capacity": 1500,  # default 100
+            "expiry": 10,  # default 60
         },
     },
 }

--- a/pong/pong/static/pong/components/PongGame.js
+++ b/pong/pong/static/pong/components/PongGame.js
@@ -3,11 +3,17 @@ import { Component } from "../core/component.js";
 export class PongGame extends Component {
   constructor(router, parameters, state) {
     super(router, parameters, state);
+  }
 
+  afterPageLoaded() {
     //setting websocket
-    this.connection = this.getRouteContext("WebSocket");
-    this.connection.onmessage = this.onMessage;
+    this.connection = this.getRouteContext("PongGameWebSocket");
+    if (!this.connection) {
+      alert("connection failed");
+      this.goNextPage("/");
+    }
 
+    this.connection.onmessage = this.onMessage;
     this.canvas = this.findElement("canvas.ponggame");
     this.context = this.canvas.getContext("2d");
     this.grid = 15;
@@ -78,6 +84,7 @@ export class PongGame extends Component {
           message.contents.player2.score;
         break;
       case "room-state":
+        this.setRouteContext("PongGameWebSocket", this.connection);
         this.changePageByRoomStatus(message);
         break;
       case "tournament":

--- a/pong/pong/static/pong/components/PongGameFinished.js
+++ b/pong/pong/static/pong/components/PongGameFinished.js
@@ -13,7 +13,7 @@ export class PongGameFinished extends Component {
     this.headerComponent.afterPageLoaded();
     const tournamentWinner = this.getRouteContext("TournamentWinner");
     if (!tournamentWinner) {
-      alert("connection failed.");
+      alert("result not found.");
       this.goNextPage("/");
     } else {
       document.getElementById("tournamentWinnerName").innerHTML =

--- a/pong/pong/static/pong/components/PongGameFinished.js
+++ b/pong/pong/static/pong/components/PongGameFinished.js
@@ -18,6 +18,7 @@ export class PongGameFinished extends Component {
   };
 
   onClick = () => {
+    this.unsetRouteContext("TournamentWinner");
     this.goNextPage("/pong-game-home");
   };
 

--- a/pong/pong/static/pong/components/PongGameFinished.js
+++ b/pong/pong/static/pong/components/PongGameFinished.js
@@ -11,6 +11,15 @@ export class PongGameFinished extends Component {
     this.headerComponent = new Header(this.router, this.params, this.state);
     this.element.parentElement.prepend(this.headerComponent.element);
     this.headerComponent.afterPageLoaded();
+    const tournamentWinner = this.getRouteContext("TournamentWinner");
+    if (!tournamentWinner) {
+      alert("connection failed.");
+      this.goNextPage("/");
+    } else {
+      document.getElementById("tournamentWinnerName").innerHTML =
+        tournamentWinner;
+      this.unsetRouteContext("TournamentWinner");
+    }
   };
 
   beforePageUnload = () => {
@@ -25,7 +34,7 @@ export class PongGameFinished extends Component {
   get html() {
     return `
       <main class="text-center p-5">
-			  <h1>Congratulation <span class="text-primary">${this.getRouteContext("TournamentWinner")}</span>!!</h1>
+			  <h1>Congratulation <span id="tournamentWinnerName" class="text-primary"></span>!!</h1>
         <button class="go-back-to-game-home btn bg-success">Game Home</button>
       </main>
 		`;

--- a/pong/pong/static/pong/components/PongGameHome.js
+++ b/pong/pong/static/pong/components/PongGameHome.js
@@ -22,6 +22,7 @@ export class PongGameHome extends Component {
   };
 
   onWebSocketOpen = () => {
+    this.setRouteContext("PongGameWebSocket", this.connection);
     this.goNextPage("/pong-game-waiting");
     this.connection.send(
       JSON.stringify({ sender: "user", type: "get-room-state" }),
@@ -29,6 +30,7 @@ export class PongGameHome extends Component {
   };
 
   onWebSocketClose = () => {
+    this.unsetRouteContext("PongGameWebSocket");
     console.log("closed");
   };
 
@@ -36,6 +38,7 @@ export class PongGameHome extends Component {
     const message = JSON.parse(event.data);
     switch (message.type) {
       case "room-state":
+        this.setRouteContext("PongGameWebSocket", this.connection);
         this.changePageByRoomStatus(message);
         break;
       case "tournament":
@@ -56,7 +59,6 @@ export class PongGameHome extends Component {
     this.setRouteContext("RoomID", event.target.elements["room-id"].value);
     const socketPath = `ws://${window.location.hostname}:${window.location.port}/realtime-pong/${event.target.elements["room-id"].value}/${event.submitter.name}/`;
     this.connection = new WebSocket(socketPath);
-    this.setRouteContext("WebSocket", this.connection);
     this.connection.onopen = this.onWebSocketOpen;
     this.connection.onclose = this.onWebSocketClose;
     this.connection.onmessage = this.onMessage;
@@ -66,7 +68,6 @@ export class PongGameHome extends Component {
     this.setRouteContext("RoomID", query["room-id"]);
     const socketPath = `ws://${window.location.hostname}:${window.location.port}/realtime-pong/${query["room-id"]}/${query["name"]}/`;
     this.connection = new WebSocket(socketPath);
-    this.setRouteContext("WebSocket", this.connection);
     this.connection.onopen = this.onWebSocketOpen;
     this.connection.onclose = this.onWebSocketClose;
     this.connection.onmessage = this.onMessage;

--- a/pong/pong/static/pong/components/PongGameTournament.js
+++ b/pong/pong/static/pong/components/PongGameTournament.js
@@ -4,13 +4,22 @@ import { PongGameTournamentBracket } from "./PongGameTournamentBracket.js";
 export class PongGameTournament extends Component {
   constructor(route, parameters, state) {
     super(route, parameters, state);
+  }
+
+  afterPageLoaded() {
+    if (!this.getRouteContext("PongGameWebSocket")) {
+      alert("connection failed.");
+      this.goNextPage("/");
+    }
+    const tournamentContext = this.getRouteContext("Tournament");
     this.bracket = new PongGameTournamentBracket(
-      route,
-      parameters,
-      state,
-      this.getRouteContext("Tournament"),
+      this.route,
+      this.parameters,
+      this.state,
+      tournamentContext,
     );
     this.element.appendChild(this.bracket.element);
+    this.unsetRouteContext("Tournament");
   }
 
   get html() {

--- a/pong/pong/static/pong/components/PongGameWaiting.js
+++ b/pong/pong/static/pong/components/PongGameWaiting.js
@@ -3,7 +3,14 @@ import { Component } from "../core/component.js";
 export class PongGameWaiting extends Component {
   constructor(router, parameters, state) {
     super(router, parameters, state);
-    this.connection = this.getRouteContext("WebSocket");
+  }
+
+  afterPageLoaded() {
+    this.connection = this.getRouteContext("PongGameWebSocket");
+    if (!this.connection) {
+      alert("connection failed");
+      this.goNextPage("/");
+    }
     this.findElement("button.go-back-to-game-home").onclick = this.onClick;
   }
 

--- a/pong/pong/static/pong/components/SearchUsers.js
+++ b/pong/pong/static/pong/components/SearchUsers.js
@@ -21,6 +21,7 @@ export class SearchUsers extends Component {
     this.createSearchedUsersList(usersData);
     document.getElementById("button-to-move-home-page").onclick =
       this.goHomePage;
+    this.unsetRouteContext("searchedUsersData");
   };
 
   beforePageUnload = () => {

--- a/pong/pong/static/pong/core/component.js
+++ b/pong/pong/static/pong/core/component.js
@@ -36,6 +36,10 @@ export class Component {
     this.router.setContext(name, value);
   }
 
+  unsetRouteContext(name) {
+    this.router.unsetContext(name);
+  }
+
   findElement(query) {
     return this.element.querySelector(query);
   }

--- a/pong/pong/static/pong/core/router.js
+++ b/pong/pong/static/pong/core/router.js
@@ -23,6 +23,12 @@ export class Router {
     this.context[name] = value;
   }
 
+  unsetContext(name) {
+    if (name in this.context) {
+      delete this.context[name];
+    }
+  }
+
   getContext(name) {
     return this.context[name];
   }

--- a/pong/realtime_pong_game/consumers.py
+++ b/pong/realtime_pong_game/consumers.py
@@ -136,7 +136,8 @@ class PlayerConsumer(AsyncWebsocketConsumer):
     async def disconnect(self, close_code):
         if hasattr(self, "room_manager"):
             await self.room_manager.on_user_disconnected(self.user)
-        await self.channel_layer.group_discard(self.room_name, self.channel_name)
+        if hasattr(self, "room_name"):
+            await self.channel_layer.group_discard(self.room_name, self.channel_name)
 
     async def send_room_information(self, event):
         await self.send(text_data=json.dumps(event["contents"]))

--- a/pong/realtime_pong_game/roommanager.py
+++ b/pong/realtime_pong_game/roommanager.py
@@ -100,6 +100,11 @@ class Room:
         return True
 
     def remove_participant(self, participant):
+        if (
+            self.room_state != RoomState.Not_All_Participants_Connected
+            and self.room_state != RoomState.Finished
+        ):
+            return False
         with self.instance_lock:
             if participant in self.participants:
                 self.participants.remove(participant)
@@ -236,6 +241,7 @@ class Room:
         self.set_room_state(RoomState.Finished)
         async_to_sync(self.send_room_state_to_group)()
         async_to_sync(self.send_messege_to_group)("notify_client_proccessing_complete")
+        RoomManager.remove_instance(self.room_name)
 
     async def handle_game_action(self, participant, message_json):
         if self.participants_state[participant] == ParticipantState.Player1:


### PR DESCRIPTION
## 修正した箇所
- websocketに接続していないときに、PongGameのページに飛ばせないようにする
    - getRouteContextでwebsocketの存在を調べる
- 1ユーザーの多重接続を防ぐ
   - これまでの実装だと、多重接続された場合に、サーバー側でエラーハンドリングをしていたが、同時にゲームに登録されているユーザーの情報をRoomManagerから削除してしまっていた。
   - そのため、１回目の接続(生起の接続)に対応するユーザーの情報をRoomManagerが維持しておらず、多重接続後のキー入力でエラーとなった
   - 解決策としては、多重接続の際はユーザーを削除せず、その他のエラーハンドリングだけを行うことにした。